### PR TITLE
FIX RACE CONDITION

### DIFF
--- a/src/Demo/Demo.csproj
+++ b/src/Demo/Demo.csproj
@@ -11,10 +11,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.9.1"/>
-    <PackageReference Include="MSTest.TestFramework" Version="1.4.0"/>
-    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0"/>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0"/>
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.16.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
   </ItemGroup>
 
 </Project>

--- a/src/EventStore/CosmosEventStore.cs
+++ b/src/EventStore/CosmosEventStore.cs
@@ -103,7 +103,7 @@ namespace EventStore
         {
             var items = events.Select(e => new EventWrapper
             {
-                Id = $"{streamId}:{++expectedVersion}:{e.GetType().Name}",
+                Id = $"{streamId}:{++expectedVersion}",
                 StreamInfo = new StreamInfo
                 {
                     Id = streamId,

--- a/src/EventStore/EventStore.csproj
+++ b/src/EventStore/EventStore.csproj
@@ -3,10 +3,10 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <Folder Include="js\"/>
+    <Folder Include="js\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.9.1"/>
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.16.0" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="js\*.*">

--- a/src/Projections/Projections.csproj
+++ b/src/Projections/Projections.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.9.1"/>
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.16.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SnapshotStore/SnapshotStore.csproj
+++ b/src/SnapshotStore/SnapshotStore.csproj
@@ -3,10 +3,10 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <Folder Include="js\"/>
+    <Folder Include="js\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.9.1"/>
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.16.0" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="js\*.*">


### PR DESCRIPTION
It is possible to have 2 events for the same stream and version get written events. The SP will check the version before starting to write, however it doesn't lock the stream before writing. By not including the eventName in the Id, we will throw an error on the second event if 2 events write the same version number to the same stream. My error was when I saw 2 events like this in my events container:
stream1234:1:RegisterStream
stream1234:2:RenameStream
stream1234:2:DeactivateStream

With this fix you will expect the DeactivateStream to have returned 'false' when appending to stream.
