### PR TITLE
Added MSSQL Projections

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,11 @@
 This repository contains an example of an Event Store built on Azure Cosmos DB.
 
 It contains all demo code that I use in my Cosmos Event Sourcing talk. See [here](https://github.com/amolenk/CosmosEventSourcing/blob/master/Event%20Sourcing%20with%20Azure%20Cosmos%20DB.pdf) for the slidedeck.
+
+Demo on YouTupe: https://youtu.be/UejwRlmV6E4
+
+On 8/15/2021, Added the ability to have views written to MSSQL. (see the Readme.txt at https://github.com/marctalcott/CosmosEventSourcing/blob/main/src/Projections/MSSQL/Readme.DbScript.txt
+
+
+
+

--- a/src/Demo/Domain/Projections/DailyTotalsByWeekProjection.cs
+++ b/src/Demo/Domain/Projections/DailyTotalsByWeekProjection.cs
@@ -23,7 +23,7 @@ namespace Demo.Domain.Projections
         public override string GetViewName(string streamId, IEvent @event)
         {
             var meterId = streamId.Substring(streamId.IndexOf(':') + 1);
-            var weekNumber = GetIso8601WeekOfYear(((MeterReadingsCollected)@event).Date);
+            var weekNumber = GetIso8601WeekOfYear(((MeterReadingsCollected) @event).Date);
 
             return $"DailyTotalsByWeek:{meterId}:wk{weekNumber:00}";
         }

--- a/src/Demo/Domain/Projections/MeterProjection.cs
+++ b/src/Demo/Domain/Projections/MeterProjection.cs
@@ -1,0 +1,70 @@
+using System;
+using Demo.Domain.Events;
+using EventStore;
+using Projections;
+
+namespace Demo.Domain.Projections
+{
+    public class MeterProjection
+    {
+        public string MeterId { get; set; }
+
+        public string PostalCode { get; set; }
+
+        public string HouseNumber { get; set; }
+
+        public bool IsActivated { get; set; }
+        public bool IsRegistered { get; set; }
+
+        public int FailedActivationAttempts { get; set; }
+
+        public DateTime? LatestReadingDate { get; set; }
+        
+    }
+
+    public class MeterProjector : Projection<MeterProjection>
+    {
+        public MeterProjector()
+        {
+            RegisterHandler<MeterRegistered>(WhenMeterRegistered);
+            RegisterHandler<MeterActivated>(WhenMeterActivated);
+            RegisterHandler<MeterDeregistered>(WhenMeterDeregistered);
+            RegisterHandler<MeterActivationFailed>(WhenMeterActivationFailed);
+            RegisterHandler<MeterReadingsCollected>(WhenMeterReadingsCollected);
+        }
+
+        public override string GetViewName(string streamId, IEvent @event)
+        {
+            return streamId;
+        }
+
+        private void WhenMeterRegistered(MeterRegistered e, MeterProjection view)
+        {
+            view.MeterId = e.MeterId;
+            view.PostalCode = e.PostalCode;
+            view.HouseNumber = e.HouseNumber;
+            view.IsActivated = false; // Not active until it is activated.
+            view.IsRegistered = true;
+        }
+
+        private void WhenMeterActivated(MeterActivated e, MeterProjection view)
+        {
+            view.IsActivated = true;
+        }
+
+        private void WhenMeterDeregistered(MeterDeregistered e, MeterProjection view)
+        {
+            view.IsRegistered = false;
+        }
+
+        private void WhenMeterActivationFailed(MeterActivationFailed e, MeterProjection view)
+        {
+            view.FailedActivationAttempts++;
+        }
+
+        private void WhenMeterReadingsCollected(MeterReadingsCollected e, MeterProjection view)
+        {
+            view.LatestReadingDate = e.Date;
+        }
+    }
+}

--- a/src/Projections/Cosmos/CosmosView.cs
+++ b/src/Projections/Cosmos/CosmosView.cs
@@ -1,16 +1,16 @@
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
-namespace Projections
+namespace Projections.Cosmos
 {
-    public class View : IView
+    public class CosmosView : IView
     {
-        public View()
+        public CosmosView()
             : this(new ViewCheckpoint(), new JObject(), null)
         {
         }
 
-        public View(ViewCheckpoint logicalCheckpoint, JObject payload, string etag)
+        public CosmosView(ViewCheckpoint logicalCheckpoint, JObject payload, string etag)
         {
             Payload = payload;
             LogicalCheckpoint = logicalCheckpoint;
@@ -19,12 +19,14 @@ namespace Projections
 
         [JsonProperty("logicalCheckpoint")]
         public ViewCheckpoint LogicalCheckpoint { get; set; }
-
+        
         [JsonProperty("payload")]
         public JObject Payload { get; set; }
 
         [JsonProperty("_etag")]
         public string Etag { get;set; }
+
+        public bool IsNew { get; set; }
 
         public bool IsNewerThanCheckpoint(Change change)
         {

--- a/src/Projections/IViewRepository.cs
+++ b/src/Projections/IViewRepository.cs
@@ -7,8 +7,8 @@ namespace Projections
 {
     public interface IViewRepository
     {
-        Task<View> LoadViewAsync(string name);
+        Task<IView> LoadViewAsync(string name);
 
-        Task<bool> SaveViewAsync(string name, View view);
+        Task<bool> SaveViewAsync(string name, IView view);
     }
 }

--- a/src/Projections/MSSQL/DbSchema/Meter.cs
+++ b/src/Projections/MSSQL/DbSchema/Meter.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+
+#nullable disable
+
+namespace Projections.MSSQL.DbSchema
+{
+    public partial class Meter
+    {
+        public string MeterId { get; set; }
+        public string PostalCode { get; set; }
+        public string HouseNumber { get; set; }
+        public bool? IsActivated { get; set; }
+        public int? FailedActivationAttempts { get; set; }
+        public DateTime? LatestReadingDate { get; set; }
+        public double LogicalCheckPointLsn { get; set; }
+        public string LogicalCheckPointItemIds { get; set; }
+    }
+}

--- a/src/Projections/MSSQL/DbSchema/esdemo3Context.cs
+++ b/src/Projections/MSSQL/DbSchema/esdemo3Context.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+#nullable disable
+
+namespace Projections.MSSQL.DbSchema
+{
+    public partial class esdemo3Context : DbContext
+    {
+        public esdemo3Context()
+        {
+        }
+
+        public esdemo3Context(DbContextOptions<esdemo3Context> options)
+            : base(options)
+        {
+        }
+
+        public virtual DbSet<Meter> Meters { get; set; }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+            if (!optionsBuilder.IsConfigured)
+            {
+                #warning To protect potentially sensitive information in your connection string, you should move it out of source code. You can avoid scaffolding the connection string by using the Name= syntax to read it from configuration - see https://go.microsoft.com/fwlink/?linkid=2131148. For more guidance on storing connection strings, see http://go.microsoft.com/fwlink/?LinkId=723263.
+                optionsBuilder.UseSqlServer("server=myServer;database=myDatabase;user=myUserName;password=myPassword;");
+            }
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.HasAnnotation("Relational:Collation", "SQL_Latin1_General_CP1_CI_AS");
+
+            modelBuilder.Entity<Meter>(entity =>
+            {
+                entity.ToTable("Meter");
+
+                entity.HasIndex(e => e.MeterId, "Meter_MeterId_uindex")
+                    .IsUnique();
+
+                entity.Property(e => e.MeterId).HasMaxLength(255);
+ 
+
+                entity.Property(e => e.HouseNumber).HasMaxLength(255);
+
+                entity.Property(e => e.LatestReadingDate).HasColumnType("datetime");
+
+                entity.Property(e => e.LogicalCheckPointItemIds)
+                    .IsRequired()
+                    .HasColumnName("LogicalCheckPoint_ItemIds");
+
+                entity.Property(e => e.LogicalCheckPointLsn).HasColumnName("LogicalCheckPoint_lsn");
+
+                entity.Property(e => e.PostalCode).HasMaxLength(255);
+            });
+
+            OnModelCreatingPartial(modelBuilder);
+        }
+
+        partial void OnModelCreatingPartial(ModelBuilder modelBuilder);
+    }
+}

--- a/src/Projections/MSSQL/MSSQLProjectionEngine.cs
+++ b/src/Projections/MSSQL/MSSQLProjectionEngine.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore;
+using Microsoft.Azure.Cosmos;
+using Projections.MSSQL.DbSchema;
+
+namespace Projections.MSSQL
+{
+    public class MSSQLProjectionEngine : IProjectionEngine
+    {
+        private readonly IEventTypeResolver _eventTypeResolver;
+        private IViewRepository _viewRepository;
+        private readonly string _endpointUrl;
+        private readonly string _authorizationKey;
+        private readonly string _databaseId;
+        private readonly string _eventContainerId;
+        private readonly string _leaseContainerId;
+        private readonly List<IProjection> _projections;
+        private ChangeFeedProcessor _changeFeedProcessor;
+        
+        public MSSQLProjectionEngine(
+            IEventTypeResolver eventTypeResolver,
+            string endpointUrl,
+            string authorizationKey,
+            string databaseId,
+            string eventContainerId = "events",
+            string leaseContainerId = "leases")
+        {
+            _eventTypeResolver = eventTypeResolver;
+            _endpointUrl = endpointUrl;
+            _authorizationKey = authorizationKey;
+            _databaseId = databaseId;
+            _eventContainerId = eventContainerId;
+            _leaseContainerId = leaseContainerId;
+            _projections = new List<IProjection>();
+        }
+
+        public void RegisterProjection(IProjection projection)
+        {
+            _projections.Add(projection);
+        }
+
+        public Task StartAsync(string instanceName)
+        {
+            CosmosClient client = new CosmosClient(_endpointUrl, _authorizationKey);
+
+            Container eventContainer = client.GetContainer(_databaseId, _eventContainerId);
+            Container leaseContainer = client.GetContainer(_databaseId, _leaseContainerId);
+
+            _changeFeedProcessor = eventContainer
+                .GetChangeFeedProcessorBuilder<Change>("MSSQLProjections", HandleChangesAsync)
+                .WithInstanceName(instanceName)
+                .WithLeaseContainer(leaseContainer)
+                .WithStartTime(new DateTime(2020, 5, 1, 0, 0, 0, DateTimeKind.Utc))
+                .Build();
+
+            return _changeFeedProcessor.StartAsync();
+        }
+
+        public Task StopAsync()
+        {
+            return _changeFeedProcessor.StopAsync();
+        }
+
+        private async Task HandleChangesAsync(IReadOnlyCollection<Change> changes, CancellationToken cancellationToken)
+        {
+            foreach (var change in changes)
+            {
+                var @event = change.GetEvent(_eventTypeResolver);
+
+                var subscribedProjections = _projections
+                    .Where(projection => projection.IsSubscribedTo(@event)).ToList();
+
+                if (subscribedProjections.Any())
+                {
+                    _viewRepository = new MSSQLViewRepository(new esdemo3Context());
+                }
+
+                foreach (var projection in subscribedProjections)
+                {
+                    var viewName = projection.GetViewName(change.StreamInfo.Id, @event);
+
+                    var handled = false;
+                    while (!handled)
+                    {
+                        var view = (MSSQLView) await _viewRepository.LoadViewAsync(viewName);
+
+                        // Only update if the LSN of the change is higher than the view. This will ensure
+                        // that changes are only processed once.
+                        // NOTE: This only works if there's just a single physical partition in Cosmos DB.
+                        // TODO: To support multiple partitions we need access to the leases to store
+                        // a LSN per lease in the view. This is not yet possible in the V3 SDK.
+                        if (view.IsNewerThanCheckpoint(change))
+                        {
+                            projection.Apply(@event, view);
+
+                            view.UpdateCheckpoint(change);
+
+                            handled = await _viewRepository.SaveViewAsync(viewName, view);
+                        }
+                        else
+                        {
+                            // Already handled.
+                            handled = true;
+                        }
+
+                        if (!handled)
+                        {
+                            // Oh noos! Somebody changed the view in the meantime, let's wait and try again.
+                            await Task.Delay(100);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Projections/MSSQL/MSSQLViewRepository.cs
+++ b/src/Projections/MSSQL/MSSQLViewRepository.cs
@@ -1,0 +1,84 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Newtonsoft.Json.Linq;
+using Projections.MSSQL.DbSchema;
+
+namespace Projections.MSSQL
+{
+    public class MSSQLViewRepository : IViewRepository
+    {
+        private esdemo3Context _context;
+
+        public MSSQLViewRepository(
+            esdemo3Context context)
+        {
+            _context = context;
+        }
+
+        public async Task<IView> LoadViewAsync(string name)
+        {
+            if (!name.Contains(':'))
+            {
+                return null;
+            }
+
+            string tableName = name.Substring(0, name.IndexOf(':'));
+            string rowId = name.Substring(name.IndexOf(':') + 1);
+
+            switch (tableName.Trim().ToLower())
+            {
+                case "meter":
+                    return await GetMeterView(rowId);
+                default:
+                    return new MSSQLView();
+            }
+        }
+
+        private async Task<IView> GetMeterView(string rowId)
+        {
+            var row = await _context.Meters.AsNoTracking().SingleOrDefaultAsync(x => x.MeterId == rowId);
+            if (row == null)
+            {
+                return new MSSQLView();
+            }
+
+            var view = new MSSQLView(
+                new ViewCheckpoint()
+                {
+                    LogicalSequenceNumber = (long) row.LogicalCheckPointLsn,
+                    ItemIds = row.LogicalCheckPointItemIds.Split(",").ToList()
+                }, JObject.FromObject(row));
+            return view;
+        }
+
+        public async Task<bool> SaveViewAsync(string name, IView view)
+        {
+            var sqlView = (MSSQLView) view;
+            if (!name.Contains(':'))
+            {
+                return false;
+            }
+
+            string tableName = name.Substring(0, name.IndexOf(':'));
+            string rowId = name.Substring(name.IndexOf(':') + 1);
+
+            var meter = view.Payload.ToObject<Meter>();
+            
+            // add 2 fields that are used to track 'Handled' status
+            meter.LogicalCheckPointLsn = sqlView.LogicalCheckpoint.LogicalSequenceNumber;
+            meter.LogicalCheckPointItemIds = string.Join(',', sqlView.LogicalCheckpoint.ItemIds);
+
+            if (sqlView.IsNew)
+            {
+                _context.Meters.Add(meter);
+            }
+            else
+            {
+                _context.Meters.Update(meter);
+            }
+
+            return await _context.SaveChangesAsync() > 0;
+        }
+    }
+}

--- a/src/Projections/MSSQL/MSSSQLView.cs
+++ b/src/Projections/MSSQL/MSSSQLView.cs
@@ -1,0 +1,48 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Projections.MSSQL
+{
+    public class MSSQLView : IView
+    {
+        public MSSQLView()
+            : this(new ViewCheckpoint(), new JObject())
+        {
+            IsNew = true;
+        }
+
+        public MSSQLView(ViewCheckpoint logicalCheckpoint, JObject payload)
+        {
+            Payload = payload;
+            LogicalCheckpoint = logicalCheckpoint;
+            IsNew = false;
+        }
+
+        [JsonProperty("logicalCheckpoint")] public ViewCheckpoint LogicalCheckpoint { get; set; }
+
+        [JsonProperty("payload")] public JObject Payload { get; set; }
+
+        public bool IsNew { get; }
+     
+        public bool IsNewerThanCheckpoint(Change change)
+        {
+            if (change.LogicalSequenceNumber == LogicalCheckpoint.LogicalSequenceNumber)
+            {
+                return !LogicalCheckpoint.ItemIds.Contains(change.Id);
+            }
+
+            return change.LogicalSequenceNumber > LogicalCheckpoint.LogicalSequenceNumber;
+        }
+
+        public void UpdateCheckpoint(Change change)
+        {
+            if (change.LogicalSequenceNumber != LogicalCheckpoint.LogicalSequenceNumber)
+            {
+                LogicalCheckpoint.LogicalSequenceNumber = change.LogicalSequenceNumber;
+                LogicalCheckpoint.ItemIds.Clear();
+            }
+
+            LogicalCheckpoint.ItemIds.Add(change.Id);
+        }
+    }
+}

--- a/src/Projections/MSSQL/Readme.DbScript.txt
+++ b/src/Projections/MSSQL/Readme.DbScript.txt
@@ -1,0 +1,33 @@
+ # Create a SQL database with a table that meets the criteria for your reporting (like example below).
+ # In this example I want to table that shows the current state of the Meter Aggregate.
+ 
+ # Add table definition here
+ 
+ ---
+ create table Meter
+ (
+     MeterId                   nvarchar(255) not null primary key,
+     PostalCode                nvarchar(255),
+     HouseNumber               nvarchar(255),
+     IsActivated               bit,
+     FailedActivationAttempts  int,
+     LatestReadingDate         datetime,
+     
+     -- The next 2 lines should be on all tables. They allow code to decide if a change has been applied yet.
+     LogicalCheckPoint_lsn     float         not null,
+     LogicalCheckPoint_ItemIds nvarchar(max) not null
+ )
+ go
+ 
+ create unique index Meter_MeterId_uindex
+     on Meter (MeterId)
+ go
+ 
+---
+ 
+ # Once the table is created you can run this script in your 'Projections' project root folder, and it will create your
+ # SQL EF code for you.
+ 
+ 
+
+ dotnet ef dbcontext scaffold "server=myServer;database=myDb;user=myUser;password=myPassword;" "Microsoft.EntityFrameworkCore.SqlServer" -v -f --schema dbo -o MSSQL/DbSchema

--- a/src/Projections/Projections.csproj
+++ b/src/Projections/Projections.csproj
@@ -6,10 +6,20 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.16.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="5.0.9">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\EventStore\EventStore.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="MSSQL\DbSchema" />
   </ItemGroup>
 
 </Project>

--- a/src/Projections/ViewCheckpoint.cs
+++ b/src/Projections/ViewCheckpoint.cs
@@ -15,6 +15,6 @@ namespace Projections
         public long LogicalSequenceNumber { get; set; }
 
         [JsonProperty("itemIds")]
-        public List<string> ItemIds { get; }
+        public List<string> ItemIds { get; set; }
     }
 }


### PR DESCRIPTION
An issue we have had is that people are not familiar with reading data from Azure CosmosDB, so I decided to set up a way to write views into a SQL database for reporting data. This will satisfy our needs for a way to easily run ad hoc queries. The database should be treated as a read-only reporting database.

Added MeterProjection (to be written to a MSSQL database).
In Projections project, I split out Cosmos and MSSQL for the ProjectionEngine, View, and ViewRepository.
In Projections/MSSSQL, I added infomation about the required database schema and script to create the table. 

Once the table is created in a database and you set the connection string in the dbContext (Projections/MSSQL/esdemo3Context.cs), then you can run your unit tests normally. Then run then new unit test 'DemoScenarios.SC05C_RunMSSQLProjectionsAsync()'. It will process the events and create Meter views in SQL database.
